### PR TITLE
Feat/add exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules
 
 # Slugtenberg
 dist-*
+dist
+slugtenberg.yml

--- a/bin/slugtenberg.js
+++ b/bin/slugtenberg.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const yargs = require('yargs')
+const gulp = require('gulp')
+
+const argv = yargs
+    .usage('Usage: $0 <command> [options]')
+    .command({
+        command: 'start',
+        desc: 'Start project',
+        builder: (yargs) => {
+           return yargs.example('$0 start -c slugtenberg.yml', 'loads project using the given config file')
+            .alias('c', 'config')
+            .nargs('c', 1)
+            .default('c','slugtenberg.yml')
+            .describe('c', 'configuration file')
+            .demandOption(['c'])
+            .help('help')
+            .wrap(null)
+        },
+        handler: (argv) => {
+            require('../gulpfile') // import the gulp file
+            process.nextTick(async function(){
+                await gulp.task('build')()
+                gulp.task('server:start')(()=>{
+                   gulp.task('watch')()
+                })
+            })        
+        }
+    })
+    .help('help')
+    .wrap(null)
+    .argv
+
+function checkCommands (yargs, argv, numRequired) {
+    if (argv._.length < numRequired) {
+        yargs.showHelp()
+    }
+}
+checkCommands(yargs, argv, 1)
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,36 +27,4 @@ task('build', series(
 	'build:media'
 ))
 
-task('watch', () => {
-
-	// Watch for any file used in views
-	watch([
-			'src/data/**/*',
-			'src/slugs/**/*',
-			'src/media/**/*',
-			'src/includes/**/*',
-			'src/layouts/**/*'
-		],
-		series('build:views'))
-	
-	// Watch for styles
-	watch([
-			'src/slugs/**/*+(' + lib.config.typeStyle + ')',
-			'src/styles/**/*+(' + lib.config.typeStyle + ')'
-		],
-		series('build:styles'))
-	
-	// Watch for scripts
-	watch([
-			'src/slugs/**/*+(' + lib.config.typeScript + ')',
-			'src/scripts/**/*+(' + lib.config.typeScript + ')'
-		],
-		series('build:scripts'))
-	
-	// Watch for media files in any location
-	watch([
-			'src/slugs/**/*+(' + lib.config.typeMedia + ')',
-			'src/media/**/*+(' + lib.config.typeMedia + ')'
-		],
-		series('build:media'))
-})
+task('watch', lib.watch)

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,19 +11,32 @@ const fs = require('fs')
 const yaml = require('yaml')
 
 // Customs
-const config = yaml.parse(
-	fs.readFileSync(
-		args.dev ? 'src/config-dev.yml' : 'src/config.yml', 'utf8'
+let config = {
+	baseUrl: '',
+	cdnUrl: '',
+	siteTitle: 'Slutenberg Demo',
+	siteLanguage: 'en',
+	src: '.'
+}
+
+try{
+	config = yaml.parse(
+		fs.readFileSync(args.config, 'utf8')
 	)
-)
+}catch(e){
+	if(!e.message.match(/ENOENT/i)){
+		throw e
+	}
+}
+
 
 module.exports = extend({
-	
-	debug: args.dev ? true : false,
-	outputPath: args.dev ? 'dist-dev' : 'dist',
-	assetsUrl: config.cdnUl + '/assets/',
-	stylesLink: config.cdnUrl + '/assets/styles.css',
-	scriptsLink: config.cdnUrl + '/assets/scripts.css',
+	//general
+	debug: process.env.NODE_ENV !== 'production',
+	outputPath: 'dist',
+	assetsUrl: `${config.cdnUrl}/assets/`,
+	stylesLink: `${config.cdnUrl}/assets/styles.css`,
+	scriptsLink: `${config.cdnUrl}/assets/scripts.css`,
 
 	// File Types
 	typeTemplate: '.liquid|.html',
@@ -39,8 +52,8 @@ module.exports = extend({
 	// Parsers
 	viewCache: false,
 	viewRoots: [
-		'src/layouts',
-		'src/includes'
+		`${config.src}/layouts`,
+		`${config.src}/includes`
 	],
 	strictFilters: true,
 	strictVariables: false

--- a/lib/media.js
+++ b/lib/media.js
@@ -31,11 +31,11 @@ function handleFileName(fs) {
 
 module.exports = (cb) => {
 	src([
-			'src/media/**/*',
-			'src/data/**/*+(' + config.typeMedia + ')',
-			'src/slugs/**/*+(' + config.typeMedia + ')',
-			'!src/**/_*/',
-			'!src/**/_*/**'
+			`${config.src}/media/**/*`,
+			`${config.src}/data/**/*+(${config.typeMedia})`,
+			`${config.src}/slugs/**/*+(${config.typeMedia})`,
+			`!${config.src}/**/_*/`,
+			`!${config.src}/**/_*/**`
 		])
 		.pipe(logfile('Building asset'))
 		.pipe(chmod(0644))

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -111,7 +111,7 @@ function safeSlug(fpath) {
 
 function extendSlug(slug) {
 	let output = {}
-	let dir = 'src/slugs/'
+	let dir = `${config.src}/slugs/`
 
 	if(fs.existsSync(dir + slug))
 		output = parseFolder(dir + slug)

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -22,10 +22,10 @@ const {logfile} = require('./logs.js')
 
 module.exports = (cb) => {
 	src([
-			'src/slugs/**/*+(' + config.typeScript + ')',
-			'src/scripts/**/*+(' + config.typeScript + ')', // ext force to read files only
-			'!src/**/_*/',
-			'!src/**/_*/**'
+			`${config.src}/slugs/**/*+(${config.typeScript})`,
+			`${config.src}/scripts/**/*+(${config.typeScript})`, // ext force to read files only
+			`!${config.src}/**/_*/`,
+			`!${config.src}/**/_*/**`
 		])
 		.pipe(logfile('Building script'))
 		.pipe(concat('scripts.js'))

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -21,10 +21,10 @@ const {logfile} = require('./logs.js')
 
 module.exports = (cb) => {
 	src([
-			'src/slugs/**/*+(' + config.typeStyle + ')',
-			'src/styles/**/*+(' + config.typeStyle + ')', // ext force to read files only
-			'!src/**/_*/',
-			'!src/**/_*/**'
+			`${config.src}/slugs/**/*+(${config.typeStyle})`,
+			`${config.src}/styles/**/*+(${config.typeStyle})`, // ext force to read files only
+			`!${config.src}/**/_*/`,
+			`!${config.src}/**/_*/**`
 		])
 		.pipe(logfile('Building style'))
 		.pipe(

--- a/lib/views.js
+++ b/lib/views.js
@@ -197,7 +197,7 @@ function handleDataSheets(filepath, globals) {
 		loaded.forEach((v,i,a) => {
 			v.slug = parser.make((i + 1) + '-' + v[options.column_slug]);
 
-			src('src/layouts/' + options.use_layout + '+(' + config.typeTemplate + ')')
+			src(`${config.src}/layouts/${options.use_layout}+(${config.typeTemplate})`)
 				.pipe(logfile('Building view@data', options.name + '/' + v.slug))
 				.pipe(data((f) => handleSlugData(v)))
 				.pipe(liquid(ENGINE_OPTS))
@@ -229,7 +229,8 @@ function handleDataFiles(filepath, globals) {
 module.exports = (cb) => {
 	
 	// Append global data files
-	let dir = 'src/data';
+	let dir = `${config.src}/data`;
+	console.log(dir)
 	if(fs.existsSync(dir)) {
 		fs.readdirSync(dir)
 
@@ -246,9 +247,9 @@ module.exports = (cb) => {
 	}
 
 	src([
-			'src/slugs/**/*+(' + config.typeTemplate + ')',  // Ext force to read files only
-			'!src/**/_*/',
-			'!src/**/_*/**'
+			`${config.src}/slugs/**/*+(${config.typeTemplate})`,  // Ext force to read files only
+			`!${config.src}/**/_*/`,
+			`!${config.src}/**/_*/**`
 		])
 		.pipe(logfile('Building view'))
 		.pipe(data((f) => handleSlugData(f.path)))

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,0 +1,46 @@
+/* Happy Coding!
+—————————————————————————————————————————————————————————
+file:			lib/watch.js
+version: 		0.0.1
+last_changes:	.
+—————————————————————————————————————————————————————————
+*/
+const {watch, series} = require('gulp')
+
+// Customs
+const config = require('./config.js')
+
+/* ——————————————————— INITIALIZER —————————————————————— */
+
+module.exports = (cb) => {
+	// Watch for any file used in views
+	watch([
+        `${config.src}/data/**/*`,
+        `${config.src}/slugs/**/*`,
+        `${config.src}/media/**/*`,
+        `${config.src}/includes/**/*`,
+        `${config.src}/layouts/**/*`
+    ],
+    series('build:views'))
+
+    // Watch for styles
+    watch([
+            `${config.src}/slugs/**/*+(${config.typeStyle})`,
+            `${config.src}/styles/**/*+(${config.typeStyle})`
+        ],
+        series('build:styles'))
+
+    // Watch for scripts
+    watch([
+            `${config.src}/slugs/**/*+(${config.typeScript})`,
+            `${config.src}/scripts/**/*+(${config.typeScript})`
+        ],
+        series('build:scripts'))
+
+    // Watch for media files in any location
+    watch([
+            `${config.src}/slugs/**/*+(${config.typeMedia})`,
+            `${config.src}/media/**/*+(${config.typeMedia})`
+        ],
+        series('build:media'))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,8 +1052,7 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2667,8 +2666,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -7686,8 +7684,7 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
@@ -8214,8 +8211,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -9694,156 +9690,170 @@
 			}
 		},
 		"yargs": {
-			"version": "14.2.3",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-			"dev": true,
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
 			"requires": {
-				"cliui": "^5.0.0",
+				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
+				"find-up": "^4.1.0",
 				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
+				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^15.0.1"
+				"yargs-parser": "^18.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
 				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 				},
 				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
 					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
 					}
 				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 					"requires": {
-						"locate-path": "^3.0.0"
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
 				"get-caller-file": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 				},
 				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
 				},
 				"p-try": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"require-main-filename": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 				},
 				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "^5.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yargs-parser": {
-					"version": "15.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-					"dev": true,
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"homepage": "https://github.com/owner/project#readme",
 	"license": "MIT",
 	"version": "0.0.1",
+	"main": "bin/slugtenberg.js",
 	"description": "gulpfile.js",
 	"repository": {
 		"type": "git",
@@ -38,8 +39,7 @@
 		"require-dir": "^1.2.0",
 		"through2": "^3.0.1",
 		"xml2json": "^0.12.0",
-		"yaml": "^1.9.2",
-		"yargs": "^14.2.0"
+		"yaml": "^1.9.2"
 	},
 	"scripts": {
 		"prod": "gulp build",
@@ -53,5 +53,8 @@
 		"commitizen": {
 			"path": "./node_modules/cz-conventional-changelog"
 		}
+	},
+	"dependencies": {
+		"yargs": "^15.3.1"
 	}
 }


### PR DESCRIPTION
using `./bin/slugtenberg.js start` runs the tasks build, server and watch using `./slugtenberg.yml`  as default config.  You can modify the config file sending `-c path/to/file.yml`.

### ToDo:
- add `export` action. This should be the default action that builds the project
- add `init` action. This generates the folder structure needed for slugtenberg
